### PR TITLE
0.0.1-alpha.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .pub/
 .dart_tool/
 pubspec.lock
+**/pubspec.lock
 
 Podfile
 Podfile.lock

--- a/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/example/macos/Runner.xcodeproj/project.pbxproj
@@ -441,7 +441,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12.2;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};
@@ -575,7 +575,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12.2;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 5.0;
@@ -601,7 +601,7 @@
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
-				MACOSX_DEPLOYMENT_TARGET = 10.12.2;
+				MACOSX_DEPLOYMENT_TARGET = 10.11;
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_VERSION = 5.0;
 			};

--- a/touch_bar/CHANGELOG.md
+++ b/touch_bar/CHANGELOG.md
@@ -8,3 +8,6 @@
 - Implement MethodChannelTouchBar in TouchBarInterface and make it the default implementation of TouchBarPlatform
 - Remove unnecessary dependency of TouchBarInterface from TouchBarMacOS
 - Fix macos version in podspec
+
+## 0.0.1-alpha.3
+- Add compatibility to macOS version above 10.11: the plugin does not have any use for MacOS below 10.12.2 (TouchBar is available since macOS 10.12.2) but now, the plugin can be used in projects targeting macOS 10.11 without raising any build errors.

--- a/touch_bar/CHANGELOG.md
+++ b/touch_bar/CHANGELOG.md
@@ -2,4 +2,9 @@
 - Initial open-source release.
 
 ## 0.0.1-alpha.1
-- Fix dependencies in pubspec
+- Fix dependencies in pubspec.
+
+## 0.0.1-alpha.2
+- Implement MethodChannelTouchBar in TouchBarInterface and make it the default implementation of TouchBarPlatform
+- Remove unnecessary dependency of TouchBarInterface from TouchBarMacOS
+- Fix macos version in podspec

--- a/touch_bar/macos/touch_bar.podspec
+++ b/touch_bar/macos/touch_bar.podspec
@@ -17,5 +17,5 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
 
   s.platform = :osx
-  s.osx.deployment_target = ' 10.12.2'
+  s.osx.deployment_target = '10.11'
 end

--- a/touch_bar/pubspec.yaml
+++ b/touch_bar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: touch_bar
 description: A Flutter plugin to interact with the touch bar of supported models of MacBook Pro, providing dynamic contextual controls.
-version: 0.0.1-alpha.1
+version: 0.0.1-alpha.2
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 

--- a/touch_bar/pubspec.yaml
+++ b/touch_bar/pubspec.yaml
@@ -1,6 +1,6 @@
 name: touch_bar
 description: A Flutter plugin to interact with the touch bar of supported models of MacBook Pro, providing dynamic contextual controls.
-version: 0.0.1-alpha.2
+version: 0.0.1-alpha.3
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 

--- a/touch_bar_macos/CHANGELOG.md
+++ b/touch_bar_macos/CHANGELOG.md
@@ -2,4 +2,7 @@
 - Initial open-source release.
 
 ## 0.0.1-alpha.1
-- Fix dependencies in pubspec
+- Fix dependencies in pubspec.
+
+## 0.0.1-alpha.2
+- Fix macos version in podspec.

--- a/touch_bar_macos/CHANGELOG.md
+++ b/touch_bar_macos/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 ## 0.0.1-alpha.2
 - Fix macos version in podspec.
+
+## 0.0.1-alpha.3
+- Add compatibility to macOS version above 10.11: the plugin does not have any use for MacOS below 10.12.2 (TouchBar is available since macOS 10.12.2) but now, the plugin can be used in projects targeting macOS 10.11 without raising any build errors.

--- a/touch_bar_macos/macos/Classes/Models/ScrubberMode.swift
+++ b/touch_bar_macos/macos/Classes/Models/ScrubberMode.swift
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
+@available(OSX 10.12.2, *)
 enum ScrubberMode {
   case fixed
   case free

--- a/touch_bar_macos/macos/Classes/Models/ScrubberSelectionStyle.swift
+++ b/touch_bar_macos/macos/Classes/Models/ScrubberSelectionStyle.swift
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
+@available(OSX 10.12.2, *)
 enum ScrubberSelectionStyle {
   case roundedBackground
   case outlineOverlay

--- a/touch_bar_macos/macos/Classes/Models/TouchBar.swift
+++ b/touch_bar_macos/macos/Classes/Models/TouchBar.swift
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
+@available(OSX 10.12.2, *)
 class TouchBar: NSTouchBar, NSTouchBarDelegate {
   let touchBarItemFactory = TouchBarItemFactory()
   let items: NSArray

--- a/touch_bar_macos/macos/Classes/Models/TouchBarButton.swift
+++ b/touch_bar_macos/macos/Classes/Models/TouchBarButton.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@available(OSX 10.12.2, *)
 class TouchBarButton: NSCustomTouchBarItem, TouchBarItem {
   var onClick : String?
 

--- a/touch_bar_macos/macos/Classes/Models/TouchBarItem.swift
+++ b/touch_bar_macos/macos/Classes/Models/TouchBarItem.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@available(OSX 10.12.2, *)
 protocol TouchBarItem: NSTouchBarItem {
   init?(identifier: NSTouchBarItem.Identifier, withData itemData: NSDictionary);
 

--- a/touch_bar_macos/macos/Classes/Models/TouchBarLabel.swift
+++ b/touch_bar_macos/macos/Classes/Models/TouchBarLabel.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@available(OSX 10.12.2, *)
 class TouchBarLabel: NSCustomTouchBarItem, TouchBarItem {
   required init?(identifier: NSTouchBarItem.Identifier, withData itemData: NSDictionary) {
     super.init(identifier: identifier)

--- a/touch_bar_macos/macos/Classes/Models/TouchBarPopover.swift
+++ b/touch_bar_macos/macos/Classes/Models/TouchBarPopover.swift
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
+@available(OSX 10.12.2, *)
 class TouchBarPopover: NSPopoverTouchBarItem, TouchBarItem, NSTouchBarDelegate {
   required init?(identifier: NSTouchBarItem.Identifier, withData itemData: NSDictionary) {
     super.init(identifier: identifier)

--- a/touch_bar_macos/macos/Classes/Models/TouchBarScrubber.swift
+++ b/touch_bar_macos/macos/Classes/Models/TouchBarScrubber.swift
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
+@available(OSX 10.12.2, *)
 class TouchBarScrubber: NSCustomTouchBarItem, TouchBarItem, NSTouchBarDelegate {
   static let ScrubberTextItemIdentifier = NSUserInterfaceItemIdentifier("ScrubberTextItem")
   static let ScrubberImageItemIdentifier = NSUserInterfaceItemIdentifier("ScrubberImageItem")
@@ -101,6 +102,7 @@ class TouchBarScrubber: NSCustomTouchBarItem, TouchBarItem, NSTouchBarDelegate {
   }
 }
 
+@available(OSX 10.12.2, *)
 extension TouchBarScrubber: NSScrubberDataSource, NSScrubberDelegate {
   func numberOfItems(for scrubber: NSScrubber) -> Int {
     return self.children.count
@@ -136,6 +138,7 @@ extension TouchBarScrubber: NSScrubberDataSource, NSScrubberDelegate {
   }
 }
 
+@available(OSX 10.12.2, *)
 extension TouchBarScrubber: NSScrubberFlowLayoutDelegate {
   func scrubber(_ scrubber: NSScrubber, layout: NSScrubberFlowLayout, sizeForItemAt itemIndex: Int) -> NSSize {
     let margin: CGFloat = 14

--- a/touch_bar_macos/macos/Classes/TouchBarItemFactory.swift
+++ b/touch_bar_macos/macos/Classes/TouchBarItemFactory.swift
@@ -4,6 +4,7 @@
 
 import Foundation
 
+@available(OSX 10.12.2, *)
 class TouchBarItemFactory {
   public func get(touchBarItem: NSDictionary, withIdentifier identifier: NSTouchBarItem.Identifier) -> NSTouchBarItem? {
     guard let type: String = touchBarItem["type"] as? String else {

--- a/touch_bar_macos/macos/Classes/TouchBarPlugin.swift
+++ b/touch_bar_macos/macos/Classes/TouchBarPlugin.swift
@@ -6,9 +6,9 @@ import FlutterMacOS
 import Foundation
 import AppKit
 
-@available(macOS 10.12.2, *)
 public class TouchBarPlugin: FlutterViewController, FlutterPlugin {
   static var channel: FlutterMethodChannel!
+  @available(OSX 10.12.2, *)
   static var touchBars: [TouchBar] = []
 
   public static func register(with registrar: FlutterPluginRegistrar) {
@@ -21,11 +21,20 @@ public class TouchBarPlugin: FlutterViewController, FlutterPlugin {
     )
 
     let instance = TouchBarPlugin()
-    NotificationCenter.default.addObserver(instance, selector: #selector(bindTouchBar), name: NSApplication.didBecomeActiveNotification, object: nil)
+
+    if #available(macOS 10.12.2, *) {
+      NotificationCenter.default.addObserver(instance, selector: #selector(bindTouchBar), name: NSApplication.didBecomeActiveNotification, object: nil)
+    }
+
     registrar.addMethodCallDelegate(instance, channel: channel)
   }
 
   public func handle(_ call: FlutterMethodCall, result: @escaping FlutterResult) {
+    guard #available(macOS 10.12.2, *) else {
+      // The plugin will not be used in macOS version below 10.12.2.
+      return
+    }
+
     switch call.method {
     case "setTouchBar":
       guard let touchBarJson = (call.arguments as? NSDictionary)?["touch_bar"] as? NSDictionary,
@@ -50,6 +59,7 @@ public class TouchBarPlugin: FlutterViewController, FlutterPlugin {
     }
   }
 
+  @available(OSX 10.12.2, *)
   @objc func bindTouchBar() {
     NSApp.mainWindow?.bind(NSBindingName(#keyPath(touchBar)), to: self, withKeyPath: #keyPath(touchBar), options: nil)
   }

--- a/touch_bar_macos/macos/touch_bar_macos.podspec
+++ b/touch_bar_macos/macos/touch_bar_macos.podspec
@@ -15,9 +15,8 @@ Pod::Spec.new do |s|
   s.source           = { :path => 'https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar_macos' }
   s.source_files = 'Classes/**/*'
   s.dependency 'FlutterMacOS'
-  s.platform = :osx, '10.12.2'
 
-  s.osx.deployment_target = '10.12.2'
+  s.platform = :osx, '10.11'
   s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES' }
   s.swift_version = '5.0'
 end

--- a/touch_bar_macos/pubspec.yaml
+++ b/touch_bar_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: touch_bar_macos
 description: macOS implementation of the touch_bar plugin.
-version: 0.0.1-alpha.1
+version: 0.0.1-alpha.2
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar_macos
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 

--- a/touch_bar_macos/pubspec.yaml
+++ b/touch_bar_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: touch_bar_macos
 description: macOS implementation of the touch_bar plugin.
-version: 0.0.1-alpha.2
+version: 0.0.1-alpha.3
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar_macos
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 

--- a/touch_bar_platform_interface/CHANGELOG.md
+++ b/touch_bar_platform_interface/CHANGELOG.md
@@ -6,3 +6,6 @@
 
 ## 0.0.1-alpha.2
 - Remove pubspec.lock.
+
+## 0.0.1-alpha.3
+- Use TouchBarMessageCodec to support messages containing objects like color and images.

--- a/touch_bar_platform_interface/CHANGELOG.md
+++ b/touch_bar_platform_interface/CHANGELOG.md
@@ -1,2 +1,8 @@
 ## 0.0.1-alpha
 - Initial open-source release.
+
+## 0.0.1-alpha.1
+- Implement MethodChannelTouchBar in TouchBarInterface and make it the default implementation of TouchBarPlatform.
+
+## 0.0.1-alpha.2
+- Remove pubspec.lock.

--- a/touch_bar_platform_interface/lib/method_channel_touch_bar.dart
+++ b/touch_bar_platform_interface/lib/method_channel_touch_bar.dart
@@ -7,8 +7,12 @@ import 'dart:async';
 import 'package:flutter/services.dart';
 import 'package:touch_bar_platform_interface/models/touch_bar.dart';
 import 'package:touch_bar_platform_interface/touch_bar_platform_interface.dart';
+import 'package:touch_bar_platform_interface/utils/touch_bar_message_codec.dart';
 
-const MethodChannel _channel = MethodChannel('plugins.flutter.io/touch_bar');
+const MethodChannel _channel = MethodChannel(
+  'plugins.flutter.io/touch_bar',
+  StandardMethodCodec(TouchBarMessageCodec()),
+);
 
 /// An implementation of [TouchBarPlatform] that uses method channels.
 class MethodChannelTouchBar extends TouchBarPlatform {

--- a/touch_bar_platform_interface/pubspec.yaml
+++ b/touch_bar_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: touch_bar_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 description: A common platform interface for the touch_bar plugin.
-version: 0.0.1-alpha.2
+version: 0.0.1-alpha.3
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar_platform_interface
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 

--- a/touch_bar_platform_interface/pubspec.yaml
+++ b/touch_bar_platform_interface/pubspec.yaml
@@ -2,7 +2,7 @@ name: touch_bar_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 description: A common platform interface for the touch_bar plugin.
-version: 0.0.1-alpha.1
+version: 0.0.1-alpha.2
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar_platform_interface
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 


### PR DESCRIPTION
Add compatibility to macOS version above 10.11: the plugin does not have any use for MacOS below 10.12.2 (TouchBar is available since macOS 10.12.2) but now, the plugin can be used in projects targeting macOS 10.11 without raising any build errors.