### PR TITLE
Null-safety Part 1

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -11,9 +11,9 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
-  Color themeColor = Colors.blue;
+  MaterialColor themeColor = Colors.blue;
 
-  void _changeThemeColor(Color color) {
+  void _changeThemeColor(MaterialColor color) {
     setState(() {
       themeColor = color;
     });
@@ -38,7 +38,11 @@ class _MyAppState extends State<MyApp> {
 class MyHomePage extends StatefulWidget {
   final String title;
   final Function changeThemeColor;
-  MyHomePage({Key key, this.title, this.changeThemeColor}) : super(key: key);
+  MyHomePage({
+    Key? key,
+    required this.title,
+    required this.changeThemeColor,
+  }) : super(key: key);
 
   @override
   _MyHomePageState createState() => _MyHomePageState();
@@ -75,14 +79,14 @@ class _MyHomePageState extends State<MyHomePage> {
     showCloseButton: true,
   );
   int _counter = 0;
-  TouchBar bar;
-  TouchBarImage plusImage;
-  TouchBarImage minusImage;
-  TouchBarImage menuImage;
-  TouchBarImage menu2Image;
+  TouchBar? bar;
+  TouchBarImage? plusImage;
+  TouchBarImage? minusImage;
+  TouchBarImage? menuImage;
+  TouchBarImage? menu2Image;
   TouchBarLabel popoverLabel1 = TouchBarLabel('Popover 1');
   TouchBarLabel popoverLabel2 = TouchBarLabel('Popover 2');
-  TouchBarScrubber scrubber;
+  late TouchBarScrubber scrubber;
   List<TouchBarScrubberItem> scrubberChildren = [];
   bool isIncrementing = true;
   bool isHighlightingTheColor = false;
@@ -104,14 +108,14 @@ class _MyHomePageState extends State<MyHomePage> {
   );
 
   void _invertOperatorIfNeeded() {
-    Function onClick;
+    Function()? onClick;
     String label;
     String popoverLabel;
     Color color;
     ImagePosition position;
     bool popoverShowCloseButton;
-    TouchBarImage operatorImage;
-    TouchBarImage popoverImage;
+    TouchBarImage? operatorImage;
+    TouchBarImage? popoverImage;
     List<TouchBarItem> popoverChildren;
 
     bool scrubberShowArrowButtons;

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -18,7 +18,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
 
 dependencies:
   flutter:
@@ -28,7 +28,13 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^0.1.3
+  cupertino_icons: ^1.0.2
+
+dependency_overrides:
+  touch_bar_platform_interface:
+    path: ../touch_bar_platform_interface
+  touch_bar_macos:
+    path: ../touch_bar_macos
 
 dev_dependencies:
   flutter_test:

--- a/touch_bar_macos/CHANGELOG.md
+++ b/touch_bar_macos/CHANGELOG.md
@@ -9,3 +9,6 @@
 
 ## 0.0.1-alpha.3
 - Add compatibility to macOS version above 10.11: the plugin does not have any use for MacOS below 10.12.2 (TouchBar is available since macOS 10.12.2) but now, the plugin can be used in projects targeting macOS 10.11 without raising any build errors.
+
+## 0.0.1-alpha.4
+- Null safety

--- a/touch_bar_macos/pubspec.yaml
+++ b/touch_bar_macos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: touch_bar_macos
 description: macOS implementation of the touch_bar plugin.
-version: 0.0.1-alpha.3
+version: 0.0.1-alpha.4
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar_macos
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 
@@ -12,13 +12,12 @@ flutter:
         fileName: touch_bar_macos.dart
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.8 <2.0.0"
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.8
 
 dev_dependencies:
-  pedantic: ^1.9.0
+  pedantic: ^1.9.2

--- a/touch_bar_platform_interface/CHANGELOG.md
+++ b/touch_bar_platform_interface/CHANGELOG.md
@@ -9,3 +9,6 @@
 
 ## 0.0.1-alpha.3
 - Use TouchBarMessageCodec to support messages containing objects like color and images.
+
+## 0.0.1-alpha.4
+- Null safety

--- a/touch_bar_platform_interface/lib/method_channel_touch_bar.dart
+++ b/touch_bar_platform_interface/lib/method_channel_touch_bar.dart
@@ -17,7 +17,7 @@ const MethodChannel _channel = MethodChannel(
 /// An implementation of [TouchBarPlatform] that uses method channels.
 class MethodChannelTouchBar extends TouchBarPlatform {
   @override
-  Future<void> setTouchBar(AbstractTouchBar touchBar) {
+  Future<void> setTouchBar(AbstractTouchBar touchBar) async {
     _channel.invokeMethod('setTouchBar', touchBar.toMap());
     _channel.setMethodCallHandler((call) async {
       touchBar.callMethod(call.method, call.arguments);
@@ -28,12 +28,12 @@ class MethodChannelTouchBar extends TouchBarPlatform {
 
   @override
   Future<void> setTouchBarItem({
-    int id,
-    String type,
-    Map<String, dynamic> dataChanges,
+    int? id,
+    String? type,
+    Map<String, dynamic>? dataChanges,
   }) {
     return _channel.invokeMethod('setTouchBarItem', {
-      ...dataChanges,
+      ...dataChanges!,
       'id': id,
       'type': type,
     });

--- a/touch_bar_platform_interface/lib/models/labeled_image.dart
+++ b/touch_bar_platform_interface/lib/models/labeled_image.dart
@@ -24,9 +24,9 @@ enum ImagePosition {
 
 /// Stores a [label], [image], and the [imagePosition].
 class LabeledImage {
-  String label;
-  TouchBarImage image;
-  ImagePosition imagePosition;
+  String? label;
+  TouchBarImage? image;
+  ImagePosition? imagePosition;
 
   /// Creates an instance of a [LabeledImage] with the given [image], [label]
   /// and [imagePosition].

--- a/touch_bar_platform_interface/lib/models/touch_bar.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar.dart
@@ -1,8 +1,6 @@
 // Copyright (c) 2020 Eduardo Vital Alencar Cunha
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
-import 'package:flutter/widgets.dart';
-import 'package:meta/meta.dart';
 import 'package:touch_bar_platform_interface/models/touch_bar_item.dart';
 import 'package:touch_bar_platform_interface/models/touch_bar_items/mixins/callable_item.dart';
 
@@ -38,7 +36,7 @@ abstract class AbstractTouchBar {
 /// A standard touch bar with no touch bar item.
 class TouchBar extends AbstractTouchBar {
   const TouchBar({
-    @required List<AbstractTouchBarItem> children,
+    required List<AbstractTouchBarItem> children,
   }) : super(children);
 
   @override

--- a/touch_bar_platform_interface/lib/models/touch_bar_image.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_image.dart
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 import 'package:flutter/services.dart';
-import 'package:meta/meta.dart';
 
 class TouchBarImage {
   final String key;
@@ -26,10 +25,10 @@ class TouchBarImage {
   /// [key] must be unique, if none is provided the path will be used as
   /// the [key] value.
   static Future<TouchBarImage> loadFrom({
-    @required String path,
-    String key,
+    required String path,
+    String? key,
   }) async {
-    assert(path != null && path != '');
+    assert(path != '');
     if (key == null) key = path;
 
     ByteData data = await rootBundle.load(path);
@@ -37,5 +36,5 @@ class TouchBarImage {
   }
 
   /// Create an instance of TouchBarImage with a [key] and [data].
-  TouchBarImage({@required this.key, @required this.data});
+  TouchBarImage({required this.key, required this.data});
 }

--- a/touch_bar_platform_interface/lib/models/touch_bar_item.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_item.dart
@@ -41,7 +41,7 @@ abstract class AbstractTouchBarItem with RenderableItem {
   final Map<String, Function> methods = {};
 
   /// The subitems of [this].
-  final List<TouchBarItem> children;
+  final List<TouchBarItem>? children;
 }
 
 /// The base type for touch bar items that do not contain others touchbars.
@@ -51,31 +51,31 @@ abstract class AbstractTouchBarItem with RenderableItem {
 /// to be able to use the [children] property.
 abstract class TouchBarItem extends AbstractTouchBarItem {
   /// The [children] property is forbbiden in [this].
-  final List<TouchBarItem> children = null;
+  final List<TouchBarItem>? children = null;
 
   TouchBarItem();
 }
 
 /// It makes touch bar items capable of having children.
 mixin _Parenthood on AbstractTouchBarItem {
-  List<TouchBarItem> get children => _children;
-  set children(List<TouchBarItem> newValue) {
+  List<TouchBarItem>? get children => _children;
+  set children(List<TouchBarItem>? newValue) {
     this.updateProperty(
       'children',
-      newValue: newValue.map((item) => item.toMap()).toList(),
+      newValue: newValue?.map((item) => item.toMap()).toList(),
     );
     this._children = newValue;
   }
 
   /// The subitems of [this].
-  List<TouchBarItem> _children;
+  List<TouchBarItem>? _children;
 }
 
 /// The base type for touch bar items that can have [children]
 /// an also be a child of another touch bar item.
 abstract class TouchBarGuardian extends AbstractTouchBarItem
     with _Parenthood, CallableItem {
-  TouchBarGuardian({List<TouchBarItem> children}) {
+  TouchBarGuardian({List<TouchBarItem>? children}) {
     this._children = children;
   }
 }
@@ -84,7 +84,7 @@ abstract class TouchBarGuardian extends AbstractTouchBarItem
 /// but cannot be a child of another touch bar item.
 abstract class TouchBarContainer extends TouchBarItem
     with _Parenthood, CallableItem {
-  TouchBarContainer({List<TouchBarItem> children}) {
+  TouchBarContainer({List<TouchBarItem>? children}) {
     this._children = children;
   }
 }

--- a/touch_bar_platform_interface/lib/models/touch_bar_items/mixins/callable_item.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_items/mixins/callable_item.dart
@@ -38,19 +38,19 @@ mixin CallableItem on AbstractTouchBarItem {
   ///
   /// **This method should not be called manually.**
   bool callMethod(String name, dynamic arguments) {
-    Function implementation = methods[name];
+    Function? implementation = methods[name];
     if (implementation != null) {
       if (arguments == null) {
-        methods[name]();
+        implementation();
       } else {
-        methods[name](arguments);
+        implementation(arguments);
       }
       return true;
     }
 
     if (children == null) return false;
 
-    for (AbstractTouchBarItem child in children) {
+    for (AbstractTouchBarItem child in children!) {
       if (child is CallableItem && child.callMethod(name, arguments) == true) {
         return true;
       }

--- a/touch_bar_platform_interface/lib/models/touch_bar_items/mixins/labelable_item.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_items/mixins/labelable_item.dart
@@ -14,33 +14,33 @@ part '../touch_bar_scrubber_label.dart';
 /// Provides the required properties and methods for touch bar items that
 /// behaves like a label.
 mixin LabelableItem on RenderableItem {
-  String get label => _label;
-  String get accessibilityLabel => _accessibilityLabel;
-  Color get textColor => _textColor;
+  String? get label => _label;
+  String? get accessibilityLabel => _accessibilityLabel;
+  Color? get textColor => _textColor;
 
-  set label(String newValue) {
+  set label(String? newValue) {
     this.updateProperty('label', newValue: newValue);
     this._label = newValue;
   }
 
-  set accessibilityLabel(String newValue) {
+  set accessibilityLabel(String? newValue) {
     this.updateProperty('accessibilityLabel', newValue: newValue);
     this._accessibilityLabel = newValue;
   }
 
-  set textColor(Color newValue) {
+  set textColor(Color? newValue) {
     this.updateProperty('color', newValue: newValue);
     this._textColor = newValue;
   }
 
   /// Label text
-  String _label;
+  String? _label;
 
   /// A succinct description of the [TouchBarLabel] used to provide accessibility
-  String _accessibilityLabel;
+  String? _accessibilityLabel;
 
   /// Color of te label text
-  Color _textColor;
+  Color? _textColor;
 
   Map<String, dynamic> toMap() => {
         'id': id,

--- a/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_button.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_button.dart
@@ -23,12 +23,12 @@ class TouchBarButton extends TouchBarItem with CallableItem {
   /// - [ImagePosition.left] if [iconPosition] is null;
   /// - otherwise the [iconPosition] value will be used.
   TouchBarButton({
-    String label,
-    String accessibilityLabel,
-    Color backgroundColor,
-    TouchBarImage icon,
-    ImagePosition iconPosition,
-    VoidCallback onClick,
+    String? label,
+    String? accessibilityLabel,
+    Color? backgroundColor,
+    TouchBarImage? icon,
+    ImagePosition? iconPosition,
+    VoidCallback? onClick,
   })  : this._accessibilityLabel = accessibilityLabel,
         this._backgroundColor = backgroundColor,
         this._labeledIcon = LabeledImage(
@@ -43,53 +43,53 @@ class TouchBarButton extends TouchBarItem with CallableItem {
   @override
   String get type => "Button";
 
-  TouchBarImage get icon => _labeledIcon.image;
-  String get label => _labeledIcon.label;
-  ImagePosition get iconPosition => _labeledIcon.imagePosition;
-  String get accessibilityLabel => _accessibilityLabel;
-  Color get backgroundColor => _backgroundColor;
+  TouchBarImage? get icon => _labeledIcon?.image;
+  String? get label => _labeledIcon?.label;
+  ImagePosition? get iconPosition => _labeledIcon?.imagePosition;
+  String? get accessibilityLabel => _accessibilityLabel;
+  Color? get backgroundColor => _backgroundColor;
 
-  set icon(TouchBarImage newValue) {
+  set icon(TouchBarImage? newValue) {
     updateProperty('icon', newValue: newValue);
-    this._labeledIcon.image = newValue;
+    this._labeledIcon?.image = newValue;
   }
 
-  set label(String newValue) {
+  set label(String? newValue) {
     updateProperty('label', newValue: newValue);
-    this._labeledIcon.label = newValue;
+    this._labeledIcon?.label = newValue;
   }
 
-  set iconPosition(ImagePosition newValue) {
+  set iconPosition(ImagePosition? newValue) {
     updateProperty('iconPosition', newValue: newValue.toString());
-    this._labeledIcon.imagePosition = newValue;
+    this._labeledIcon?.imagePosition = newValue;
   }
 
-  set accessibilityLabel(String newValue) {
+  set accessibilityLabel(String? newValue) {
     updateProperty('accessibilityLabel', newValue: newValue);
     _accessibilityLabel = newValue;
   }
 
-  set backgroundColor(Color newValue) {
+  set backgroundColor(Color? newValue) {
     updateProperty('backgroundColor', newValue: newValue);
     _backgroundColor = newValue;
   }
 
-  set onClick(VoidCallback newValue) {
+  set onClick(VoidCallback? newValue) {
     // It is necessary to change only the [onClick] implementation.
     // The identifier should remain the same since it is used only to
     // assure uniqueness.
-    this.methods['$_onClick'] = newValue;
+    if (newValue != null) this.methods['$_onClick'] = newValue;
   }
 
   /// Icon with label and iconpPosition information.
-  LabeledImage _labeledIcon;
+  LabeledImage? _labeledIcon;
 
   /// A succinct description of the [TouchBarButton] used to provide
   /// accessibility.
-  String _accessibilityLabel;
+  String? _accessibilityLabel;
 
   /// Background color of te [TouchBarButton]
-  Color _backgroundColor;
+  Color? _backgroundColor;
 
   /// The unique identifier of the method called when the button is clicked.
   ///
@@ -108,7 +108,7 @@ class TouchBarButton extends TouchBarItem with CallableItem {
     if (accessibilityLabel != null)
       map['accessibilityLabel'] = accessibilityLabel;
     if (backgroundColor != null) map['backgroundColor'] = backgroundColor;
-    if (_onClick != null) map['onClick'] = _onClick;
+    map['onClick'] = _onClick;
     if (icon != null) map['icon'] = icon;
 
     return map;

--- a/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_label.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_label.dart
@@ -9,8 +9,8 @@ class TouchBarLabel extends TouchBarItem with LabelableItem {
   /// Creates a new label item with the given [identifier] and [label].
   TouchBarLabel(
     String label, {
-    Color textColor,
-    String accessibilityLabel,
+    Color? textColor,
+    String? accessibilityLabel,
   }) {
     this._label = label;
     this._textColor = textColor;

--- a/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_popover.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_popover.dart
@@ -10,11 +10,11 @@ class TouchBarPopover extends TouchBarGuardian {
   /// Creates a new [TouchBarPopover] item with the giver [label], [icon],
   /// [iconPosition] and [showCloseButton]
   TouchBarPopover({
-    String label,
-    TouchBarImage icon,
-    bool showCloseButton,
-    ImagePosition iconPosition,
-    List<TouchBarItem> children,
+    String? label,
+    TouchBarImage? icon,
+    bool? showCloseButton,
+    ImagePosition? iconPosition,
+    List<TouchBarItem>? children,
   })  : this._labeledIcon = LabeledImage(
           image: icon,
           label: label,
@@ -23,43 +23,43 @@ class TouchBarPopover extends TouchBarGuardian {
         this._showCloseButton = showCloseButton,
         super(children: children);
 
-  String get label => _labeledIcon.label;
-  TouchBarImage get icon => _labeledIcon.image;
-  ImagePosition get iconPosition => _labeledIcon.imagePosition;
-  bool get showCloseButton => _showCloseButton;
+  String? get label => _labeledIcon?.label;
+  TouchBarImage? get icon => _labeledIcon?.image;
+  ImagePosition? get iconPosition => _labeledIcon?.imagePosition;
+  bool? get showCloseButton => _showCloseButton;
 
-  set label(String newValue) {
+  set label(String? newValue) {
     this.updateProperty('label', newValue: newValue);
-    this._labeledIcon.label = newValue;
+    this._labeledIcon?.label = newValue;
   }
 
-  set icon(TouchBarImage newValue) {
+  set icon(TouchBarImage? newValue) {
     this.updateProperty('icon', newValue: newValue);
-    this._labeledIcon.image = newValue;
+    this._labeledIcon?.image = newValue;
   }
 
-  set iconPosition(ImagePosition newValue) {
+  set iconPosition(ImagePosition? newValue) {
     this.updateProperty('iconPosition', newValue: newValue.toString());
-    this._labeledIcon.imagePosition = newValue;
+    this._labeledIcon?.imagePosition = newValue;
   }
 
-  set showCloseButton(bool newValue) {
+  set showCloseButton(bool? newValue) {
     this.updateProperty('showCloseButton', newValue: newValue);
     this._showCloseButton = newValue;
   }
 
   /// Icon with label and iconpPosition information.
-  LabeledImage _labeledIcon;
+  LabeledImage? _labeledIcon;
 
   /// Determines if the popover when opened will show a native close icon.
-  bool _showCloseButton;
+  bool? _showCloseButton;
 
   @override
   Map<String, dynamic> toMap() {
     Map<String, dynamic> map = {
       'id': id,
       'type': type,
-      'children': children.map((item) => item.toMap()).toList(),
+      'children': children?.map((item) => item.toMap()).toList(),
       'showCloseButton': showCloseButton,
       'iconPosition': iconPosition.toString(),
     };

--- a/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_scrubber.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_scrubber.dart
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a MIT-style license that can be
 // found in the LICENSE file.
 
-import 'package:meta/meta.dart';
 import 'package:touch_bar_platform_interface/models/touch_bar_items/mixins/callable_item.dart';
 import 'package:touch_bar_platform_interface/models/identifier.dart';
 
@@ -15,9 +14,9 @@ enum ScrubberSelectionStyle { roundedBackground, outlineOverlay, none }
 
 class TouchBarScrubber extends TouchBarContainer with CallableItem {
   TouchBarScrubber({
-    @required List<TouchBarScrubberItem> children,
-    OnItemAction onSelect,
-    OnItemAction onHighlight,
+    required List<TouchBarScrubberItem> children,
+    OnItemAction? onSelect,
+    OnItemAction? onHighlight,
     bool showArrowButtons = false,
     ScrubberSelectionStyle selectedStyle = ScrubberSelectionStyle.none,
     ScrubberSelectionStyle overlayStyle = ScrubberSelectionStyle.none,
@@ -30,8 +29,8 @@ class TouchBarScrubber extends TouchBarContainer with CallableItem {
         this._mode = mode,
         this._isContinuous = isContinuous,
         super(children: children) {
-    this.onSelect = onSelect;
-    this.onHighlight = onHighlight;
+    this.onSelect = onSelect!;
+    this.onHighlight = onHighlight!;
   }
 
   /// The unique identifier of the method called when the item is selected.
@@ -102,15 +101,15 @@ class TouchBarScrubber extends TouchBarContainer with CallableItem {
     Map<String, dynamic> map = {
       'id': id,
       'type': type,
-      'children': children.map((item) => item.toMap()).toList(),
+      'children': children?.map((item) => item.toMap()).toList(),
     };
-    if (_onSelect != null) map['onSelect'] = _onSelect;
-    if (_onHighlight != null) map['onHighlight'] = _onHighlight;
-    if (showArrowButtons != null) map['showArrowButtons'] = showArrowButtons;
-    if (selectedStyle != null) map['selectedStyle'] = selectedStyle.toString();
-    if (overlayStyle != null) map['overlayStyle'] = overlayStyle.toString();
-    if (mode != null) map['mode'] = mode.toString();
-    if (isContinuous != null) map['isContinuous'] = isContinuous;
+    map['onSelect'] = _onSelect;
+    map['onHighlight'] = _onHighlight;
+    map['showArrowButtons'] = showArrowButtons;
+    map['selectedStyle'] = selectedStyle.toString();
+    map['overlayStyle'] = overlayStyle.toString();
+    map['mode'] = mode.toString();
+    map['isContinuous'] = isContinuous;
 
     return map;
   }

--- a/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_scrubber_label.dart
+++ b/touch_bar_platform_interface/lib/models/touch_bar_items/touch_bar_scrubber_label.dart
@@ -7,8 +7,8 @@ part of 'mixins/labelable_item.dart';
 class TouchBarScrubberLabel extends TouchBarScrubberItem with LabelableItem {
   TouchBarScrubberLabel(
     String label, {
-    Color textColor,
-    String accessibilityLabel,
+    Color? textColor,
+    String? accessibilityLabel,
   }) {
     this._label = label;
     this._textColor = textColor;

--- a/touch_bar_platform_interface/lib/touch_bar_platform_interface.dart
+++ b/touch_bar_platform_interface/lib/touch_bar_platform_interface.dart
@@ -57,9 +57,9 @@ abstract class TouchBarPlatform extends PlatformInterface {
   /// ```
   ///
   void setTouchBarItem({
-    int id,
-    String type,
-    Map<String, dynamic> dataChanges,
+    int? id,
+    String? type,
+    Map<String, dynamic>? dataChanges,
   }) {
     throw UnimplementedError('setTouchBar() has not been implemented.');
   }

--- a/touch_bar_platform_interface/pubspec.lock
+++ b/touch_bar_platform_interface/pubspec.lock
@@ -7,49 +7,49 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0-nullsafety.1"
+    version: "2.5.0-nullsafety.3"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   characters:
     dependency: transitive
     description:
       name: characters
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.3"
+    version: "1.1.0-nullsafety.5"
   charcode:
     dependency: transitive
     description:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   clock:
     dependency: transitive
     description:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.15.0-nullsafety.3"
+    version: "1.15.0-nullsafety.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -66,28 +66,28 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.10-nullsafety.1"
+    version: "0.12.10-nullsafety.3"
   meta:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.6"
   path:
     dependency: transitive
     description:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.1"
+    version: "1.8.0-nullsafety.3"
   plugin_platform_interface:
     dependency: "direct main"
     description:
       name: plugin_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.0-nullsafety.1"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -99,56 +99,56 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0-nullsafety.2"
+    version: "1.8.0-nullsafety.4"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0-nullsafety.2"
+    version: "1.10.0-nullsafety.6"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.1"
+    version: "2.1.0-nullsafety.3"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0-nullsafety.1"
+    version: "1.1.0-nullsafety.3"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0-nullsafety.1"
+    version: "1.2.0-nullsafety.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19-nullsafety.2"
+    version: "0.2.19-nullsafety.6"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0-nullsafety.3"
+    version: "1.3.0-nullsafety.5"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0-nullsafety.3"
+    version: "2.1.0-nullsafety.5"
 sdks:
-  dart: ">=2.10.0-110 <=2.11.0-186.0.dev"
-  flutter: ">=1.12.8 <2.0.0"
+  dart: ">=2.12.0-0.0 <3.0.0"
+  flutter: ">=1.12.8"

--- a/touch_bar_platform_interface/pubspec.yaml
+++ b/touch_bar_platform_interface/pubspec.yaml
@@ -2,20 +2,19 @@ name: touch_bar_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
 description: A common platform interface for the touch_bar plugin.
-version: 0.0.1-alpha.3
+version: 0.0.1-alpha.4
 homepage: https://github.com/vital-edu/touch_bar_flutter_plugin/tree/master/touch_bar_platform_interface
 repository: https://github.com/vital-edu/touch_bar_flutter_plugin/
 
 dependencies:
   flutter:
     sdk: flutter
-  meta: ^1.1.8
-  plugin_platform_interface: ^1.0.2
+  plugin_platform_interface: ^1.1.0-nullsafety.1
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.8 <2.0.0"


### PR DESCRIPTION
This is basically the first half of what needs to be done about #8. It migrates the platform_interface and macos packages to Sound Null Safety and the example to Unsafe Null Safety for testing purposes. Migrating the touch_bar package _properly_ requires the other two to first be published to pub.